### PR TITLE
fix(scheduler): add vercel cron config

### DIFF
--- a/supabase/migrations/20260316000004_disable_supabase_scrape_cron.sql
+++ b/supabase/migrations/20260316000004_disable_supabase_scrape_cron.sql
@@ -1,0 +1,15 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_extension
+    WHERE extname = 'pg_cron'
+  ) THEN
+    EXECUTE $sql$
+      SELECT cron.unschedule(jobid)
+      FROM cron.job
+      WHERE jobname = 'scrape-blood-data-daily'
+    $sql$;
+  END IF;
+END
+$$;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/scrape",
+      "schedule": "0 22 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` so Vercel Cron calls `/api/cron/scrape` daily at 07:00 KST
- add a Supabase migration to unschedule the legacy `scrape-blood-data-daily` pg_cron job
- keep scheduler ownership on the existing Next.js cron route

## Validation
- `npm run lint`
- `npm run build`

Closes #3